### PR TITLE
distort in x and y using r and g channels

### DIFF
--- a/addons/Mirror/Mirror/Mirror.gdshader
+++ b/addons/Mirror/Mirror/Mirror.gdshader
@@ -26,7 +26,7 @@ void fragment() {
 		m_UV.x = 1.0 - m_UV.x;
 	}
 	
-	float distort_ofs = texture(distort_tex, m_UV).r;
+	vec2 distort_ofs = texture(distort_tex, m_UV).rg;
 	
 	// Map offset to [-1, 1] region
 	distort_ofs = (distort_ofs * 2.0) - 1.0;


### PR DESCRIPTION
The original distortion is only in the [-x, -y] to [+x, +y] along a single diagonal line. Modified it to distort x and y by the r and g channels in the distort-tex instead.
This isn't physically accurate, but helps sell the effect for small-scale ripples a lot better.